### PR TITLE
Adds support for values that doesn't exist in the select options

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ function onInputKeyDown(event) {
 | addLabelText | string | 'Add "{label}"?' | text to display when `allowCreate` is true |
 | arrowRenderer | func | undefined | Renders a custom drop-down arrow to be shown in the right-hand side of the select: `arrowRenderer({ onMouseDown, isOpen })`. Won't render when set to `null`
 | autoBlur | bool | false | Blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices |
+| allowMissingOptions | bool | false | allows the value prop to have entries that are not listed in the options props |
 | autofocus | bool | undefined | autofocus the component on mount |
 | autoload | bool | true | whether to auto-load the default async options set |
 | autosize | bool | true | If enabled, the input will expand as the length of its value increases |

--- a/src/Select.js
+++ b/src/Select.js
@@ -491,6 +491,7 @@ class Select extends React.Component {
 		for (var i = 0; i < options.length; i++) {
 			if (options[i][valueKey] === value) return options[i];
 		}
+		if (props.allowMissingOptions) return value;
 	}
 
 	setValue (value) {
@@ -1052,10 +1053,11 @@ Select.propTypes = {
 	'aria-describedby': PropTypes.string, // HTML ID(s) of element(s) that should be used to describe this input (for assistive tech)
 	'aria-label': PropTypes.string,       // Aria label (for assistive tech)
 	'aria-labelledby': PropTypes.string,  // HTML ID of an element that should be used as the label (for assistive tech)
+	allowMissingOptions: PropTypes.bool,  // allows the value prop to have entries that are not listed in the options props
 	arrowRenderer: PropTypes.func,        // Create drop-down caret element
 	autoBlur: PropTypes.bool,             // automatically blur the component when an option is selected
-	autofocus: PropTypes.bool,            // deprecated; use autoFocus instead
 	autoFocus: PropTypes.bool,            // autofocus the component on mount
+	autofocus: PropTypes.bool,            // deprecated; use autoFocus instead
 	autosize: PropTypes.bool,             // whether to enable autosizing or not
 	backspaceRemoves: PropTypes.bool,     // whether backspace removes an item if there is no text input
 	backspaceToRemoveMessage: PropTypes.string,  // Message to use for screenreaders to press backspace to remove the current item - {label} is replaced with the item label
@@ -1125,6 +1127,7 @@ Select.propTypes = {
 
 Select.defaultProps = {
 	arrowRenderer: defaultArrowRenderer,
+	allowMissingOptions: false,
 	autosize: true,
 	backspaceRemoves: true,
 	backspaceToRemoveMessage: 'Press backspace to remove {label}',

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1693,6 +1693,32 @@ describe('Select', () => {
 		});
 	});
 
+	describe('with allowMissingOptions=true', () => {
+		beforeEach(() => {
+			options = [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two', clearableValue: false },
+				{ value: 'three', label: 'Three' },
+				{ value: 'four', label: 'Four' }
+			];
+
+			// Render an instance of the component
+			wrapper = createControlWithWrapper({
+				value: [{ value: 'five', label: 'Five' }],
+				options: options,
+				searchable: true,
+				multi: true
+			});
+		});
+
+		it('renders a value that is not in the options', () => {
+			expect(instance, 'to contain',
+				<span className="Select-multi-value-wrapper">
+					<div><span className="Select-value-label">Five</span></div>
+				</span>);
+		});
+	});
+
 	describe('with multi-select', () => {
 
 		beforeEach(() => {


### PR DESCRIPTION
In this patch, we added a new prop named **allowMissingOptions** that when set to true, will allow the select to contain values that aren't in the list of options.